### PR TITLE
Features/end to end

### DIFF
--- a/mozetl/taar/taar_ensemble.py
+++ b/mozetl/taar/taar_ensemble.py
@@ -94,16 +94,6 @@ def evaluate_algorithm(dataset, n_folds, **kwargs):
     return scores
 
 
-# Make predictions with sub-models and construct a new stacked row
-def to_stacked_row(recommendation_outputs, row):
-    stacked_row = list()
-    for prediction, recommender in zip(recommendation_outputs, RECOMMENDERS):
-        prediction = recommender(prediction, row)
-        stacked_row.append(prediction)
-    stacked_row.append(row[-1])
-    return row[0:len(row) - 1] + stacked_row
-
-
 # Stacked Generalization Algorithm
 # this is where the actual work is, we need to get a comparable flow
 # utilizing the TAAR models as with these on the standard ML models,


### PR DESCRIPTION
This drops one dead function block from taar_ensemble.py and significantly reworks how credentials work for the taar_dynamo script.

Basically we need to assume a production role to write to the prod dynamo tables.  This credential is cached for 30 minutes, but we renew the credential on a 25 minute basis.

This seems to work on a subsampled RDD with 346 records in my own testing. 